### PR TITLE
utils: Add mapping for .opus to audio/opus mime-type

### DIFF
--- a/utils.php
+++ b/utils.php
@@ -13,6 +13,8 @@ class Utils
                 return 'text/css';
             case 'js':
                 return 'application/javascript';
+            case 'opus':
+                return 'audio/opus';
         }
 
         $finfo = finfo_open(FILEINFO_MIME_TYPE);


### PR DESCRIPTION
PHP uses httpd's mime-types mapping, which doesn't have a mapping of
.opus to audio/opus [1].

[1] https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types