### PR TITLE
utils: Change opus media type to 'audio/ogg; codecs=opus'

### DIFF
--- a/utils.php
+++ b/utils.php
@@ -14,7 +14,7 @@ class Utils
             case 'js':
                 return 'application/javascript';
             case 'opus':
-                return 'audio/opus';
+                return 'audio/ogg; codecs=opus';
         }
 
         $finfo = finfo_open(FILEINFO_MIME_TYPE);


### PR DESCRIPTION
The previous value of 'audio/opus' is to be used for RTP only [1].
RFC-7845 specifies the correct value to be used [2]. This allows media
to be played in-browser when Content-Disposition is set to inline.

[1] https://tools.ietf.org/html/rfc7587#section-6
[2] https://tools.ietf.org/html/rfc7845#section-9